### PR TITLE
fixed Host handling and Https example

### DIFF
--- a/neko/tls/Socket.hx
+++ b/neko/tls/Socket.hx
@@ -37,7 +37,7 @@ class Socket {
 	
 	public function connect( host : Host, port : Int ) {
 		try {
-			socket_connect(__s, host, port);
+			socket_connect(__s, host.ip, port);
 			ssl = SSL_new( ctx );
 			input.ssl = ssl;
 			output.ssl = ssl;
@@ -46,7 +46,7 @@ class Socket {
 			var rsc : Int = SSL_connect(ssl);
 		} catch( e : String ) {
 			if( e == "std@socket_connect" )
-				throw "Failed to connect on "+(try reverse(host) catch( e : Dynamic ) hostToString(host))+":"+port;
+				throw "Failed to connect on "+(try host.reverse() catch( e : Dynamic ) host.toString() ) +":" + port;
 			else
 				neko.Lib.rethrow( e );
 		}
@@ -153,30 +153,10 @@ class Socket {
 		};
 	}
 
-	public static function resolve( host : String ) : Host {
-		return host_resolve( neko.Lib.haxeToNeko( host ) );
-	}
-
-	public static function hostToString( host : Host ) : String {
-		return new String(host_to_string( host ) );
-	}
-
-	public static function reverse( host : Host ) : String {
-		return new String( host_reverse( host ) );
-	}
-
-	public static function localhost() : String {
-		return new String( host_local() );
-	}
-
 	static var socket_new = neko.Lib.load( "std", "socket_new", 1 );
 	static var socket_close = neko.Lib.load( "std", "socket_close", 1 );
 	static var socket_write = Loader.load( "__SSL_write", 2 );
 	static var socket_read = Loader.load( "__SSL_read", 1 );
-	static var host_resolve = neko.Lib.load( "std", "host_resolve", 1 );
-	static var host_reverse = neko.Lib.load( "std","host_reverse", 1 );
-	static var host_to_string = neko.Lib.load( "std", "host_to_string", 1 );
-	static var host_local = neko.Lib.load( "std", "host_local", 0 );
 	static var socket_connect = neko.Lib.load( "std", "socket_connect", 3 );
 	static var socket_listen = neko.Lib.load( "std", "socket_listen", 2 );
 	static var socket_select = neko.Lib.load( "std", "socket_select", 4 );

--- a/test/TestHttps.hx
+++ b/test/TestHttps.hx
@@ -1,0 +1,59 @@
+import neko.Lib;
+import neko.tls.Socket;
+
+class ClosableBytesOutput extends haxe.io.BytesOutput {
+
+   public function new() super()
+
+   override public function close() {
+      super.close();
+      onClose();
+   }
+
+   dynamic public function onClose() {}
+}
+
+class TestHttps {
+	static function main() {
+
+      var args = neko.Sys.args();
+
+      if (args.length < 1) {
+         Lib.println("Usage: TestHttps.n <url>");
+         return;
+      }
+
+      var parts = args[0].split("/");
+      var url = parts.shift() + ":443" + 
+            if (parts.length == 0) ""
+            else "/" + parts.join("/")
+            ;
+
+      Lib.println("Requesting from URL: " + url);
+
+		var https: haxe.Http = new haxe.Http(url);
+		
+      var output  = new ClosableBytesOutput();
+		
+      output.onClose = function() {
+			https.onData(
+               Lib.stringReference(output.getBytes()) );
+		};
+
+		https.onData=function(data : String) {
+			trace ("https.Data:\n"+data+"\n");			
+		}
+		
+      https.onError=function(msg : String) {
+			trace ("https.Error:"+msg+"\n");
+		}
+		
+      https.onStatus=function(status : Int){
+			trace ("https.Status:"+status+"\n");
+		}
+		
+      trace("Before async request");
+		https.customRequest(false, output, new Socket());
+		trace("After async request");		
+	}
+}

--- a/test/TestSSLSocket.hx
+++ b/test/TestSSLSocket.hx
@@ -2,9 +2,11 @@
 #if neko
 import neko.Lib;
 import neko.tls.Socket;
+import neko.net.Host;
 #else
 import cpp.Lib;
 import cpp.tls.Socket;
+import cpp.net.Host;
 #end
 
 class TestSSLSocket {
@@ -17,7 +19,7 @@ class TestSSLSocket {
 		
 		var sock = new Socket();
 		Lib.println( "Connecting to "+IP );
-		sock.connect( Socket.resolve( IP ), 443 );
+		sock.connect( new Host(IP), 443 );
 		Lib.println( "Connected." );
 		Lib.println( "Writing data to "+JABBER_HOST+" ..." );
 		sock.write( '<?xml version="1.0" encoding="UTF-8"?><stream:stream xmlns:stream="http://etherx.jabber.org/streams" xmlns="jabber:client" to="'+JABBER_HOST+'" xml:lang="en" version="1.0">');

--- a/test/build.hxml
+++ b/test/build.hxml
@@ -2,3 +2,8 @@
 -cp ../
 -neko test.n
 -main TestSSLSocket
+
+--next
+-cp ../
+-neko https_test.n
+-main TestHttps


### PR DESCRIPTION
neko.tls.Socket.resolve returned int32 but incorrectly aliased the type as neko.net.Host. Removed host-related methods from Socket and fixed the issue. Now the https example works too.
